### PR TITLE
Make h2spec less verbose by not diplaying docker output as info per default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
   <properties>
     <h2specContainerName>summerwind/h2spec</h2specContainerName>
     <h2specVersion>2.6.0</h2specVersion>
-    <jetty.version>9.4.31.v20200723</jetty.version>
+    <jetty.version>10.0.21</jetty.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/it/simple-test-fail/pom.xml
+++ b/src/it/simple-test-fail/pom.xml
@@ -18,8 +18,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.11.0</version>
           <configuration>
-            <source>8</source>
-            <target>8</target>
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
       </plugins>

--- a/src/it/simple-test/pom.xml
+++ b/src/it/simple-test/pom.xml
@@ -18,8 +18,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.11.0</version>
           <configuration>
-            <source>8</source>
-            <target>8</target>
+            <source>11</source>
+            <target>11</target>
           </configuration>
         </plugin>
       </plugins>
@@ -30,6 +30,7 @@
         <artifactId>h2spec-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>
+          <displayh2SpecOutputAsInfo>true</displayh2SpecOutputAsInfo>
           <h2specVersion>@h2specVersion@</h2specVersion>
           <h2specContainerName>@h2specContainerName@</h2specContainerName>
           <mainClass>org.eclipse.jetty.http2.server.H2SpecServer</mainClass>

--- a/src/it/simple-test/postbuild.groovy
+++ b/src/it/simple-test/postbuild.groovy
@@ -19,6 +19,7 @@
 import groovy.xml.XmlSlurper
 File buildLog = new File( basedir, 'build.log' )
 assert buildLog.text.contains( 'Container summerwind/h2spec' )
+assert buildLog.text.contains( '1: Sends a WINDOW_UPDATE frame with a flow control window increment of 0')
 File surefireFile = new File(basedir, "target/h2spec-reports/TEST-h2spec.xml")
 assert surefireFile.exists()
 def report = new XmlSlurper().parse(surefireFile)

--- a/src/main/java/org/mortbay/jetty/maven/h2spec/Http2SpecMojo.java
+++ b/src/main/java/org/mortbay/jetty/maven/h2spec/Http2SpecMojo.java
@@ -152,6 +152,12 @@ public class Http2SpecMojo extends AbstractMojo {
     private boolean skipNoDockerAvailable;
 
     /**
+     * per default log output of testcontainer will displayed as debug log if {@code true} logs will displayed as info
+     */
+    @Parameter(property = "h2spec.displayh2SpecOuutputAsInfo", defaultValue = "false")
+    private boolean displayh2SpecOutputAsInfo = false;
+
+    /**
      * maximum timeout in minutes to run all the tests
      */
     @Parameter(property = "h2spec.totalTestTimeout", defaultValue = "5")
@@ -301,7 +307,7 @@ public class Http2SpecMojo extends AbstractMojo {
                 Files.createDirectories(containerTmp);
                 DockerImageName dockerImageName = DockerImageName.parse(imageName);
                 try (GenericContainer<?> h2spec = new GenericContainer<>(dockerImageName)) {
-                    h2spec.withLogConsumer(new MojoLogConsumer(getLog()));
+                    h2spec.withLogConsumer(new MojoLogConsumer(getLog(), displayh2SpecOutputAsInfo));
                     // h2spec.setWaitStrategy(new LogMessageWaitStrategy(totalTestTimeout).withStartLine("Finished in ")
                     //                           .withStartupTimeout(Duration.ofMinutes(totalTestTimeout)));
                     h2spec.setWaitStrategy(new LogMessageWaitStrategy()
@@ -375,15 +381,21 @@ public class Http2SpecMojo extends AbstractMojo {
 
     private static class MojoLogConsumer extends ToStringConsumer {
         private Log log;
+        private boolean displayh2SpecOutputAsInfo;
 
-        public MojoLogConsumer(Log log) {
+        public MojoLogConsumer(Log log, boolean displayh2SpecOutputAsInfo) {
             this.log = log;
+            this.displayh2SpecOutputAsInfo = displayh2SpecOutputAsInfo;
         }
 
         @Override
         public void accept(OutputFrame outputFrame) {
             super.accept(outputFrame);
-            log.info(toUtf8String());
+            if (displayh2SpecOutputAsInfo) {
+                log.info(toUtf8String());
+            } else {
+                log.debug(outputFrame.toString());
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
